### PR TITLE
Adjust website width and line spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -33,7 +33,7 @@ body {
     font-family: 'Gidolinya', 'Latin Modern Roman', serif;
     background-color: #FAFAF7;
     color: #1a1918;
-    line-height: 1.6;
+    line-height: 1.7;
     padding-top: calc(var(--header-padding-y) * 2 + var(--header-content-height));
     letter-spacing: 0.005em;
     font-weight: 200;
@@ -75,7 +75,7 @@ p {
 
 /* Layout */
 main {
-    max-width: 65ch;
+    max-width: 70ch;
     margin: 2rem auto 2rem;
     padding: 0 2rem;
 }
@@ -96,7 +96,7 @@ header {
 }
 
 .header-content {
-    max-width: 65ch;
+    max-width: 70ch;
     margin: 0 auto;
     padding: 0 2rem;
     display: flex;
@@ -150,7 +150,7 @@ footer {
 }
 
 .contact-links {
-    max-width: 65ch;
+    max-width: 70ch;
     margin: 0 auto;
     padding: 2rem;
     display: flex;
@@ -457,7 +457,7 @@ footer {
 
 .post-excerpt {
     color: #545454;
-    line-height: 1.6;
+    line-height: 1.7;
     font-size: 1rem;
     font-weight: 100;
 }
@@ -700,7 +700,7 @@ footer {
     
     .post-content p {
         font-size: 1.0625rem;
-        line-height: 1.65;
+        line-height: 1.7;
         margin: 0 0 1.125rem 0;
     }
     
@@ -716,7 +716,7 @@ footer {
     
     .post-content ul li, .post-content ol li {
         font-size: 1.0625rem;
-        line-height: 1.65;
+        line-height: 1.7;
     }
     
     .post-content img {
@@ -748,9 +748,6 @@ footer {
 
     /* Dark mode mobile menu adjustments */
     @media (max-width: 768px) {
-        nav a {
-            /* No borders needed */
-        }
     }
 
     .carousel-button {


### PR DESCRIPTION
Increase main content width to 70ch and adjust line-heights to 1.7 for improved readability and a slightly wider layout.

The main content, header, and footer containers were widened from 65ch to 70ch. Base `body` line-height, blog excerpts, and mobile post content paragraphs/lists were adjusted from 1.6/1.65 to 1.7 to make text more breathable. An empty CSS rule was also removed to resolve a style warning.

---
<a href="https://cursor.com/background-agent?bcId=bc-e1f15ecf-c537-496f-8613-37f0d2b9250b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e1f15ecf-c537-496f-8613-37f0d2b9250b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

